### PR TITLE
Remove bit.ly shortening

### DIFF
--- a/src/Host.tsx
+++ b/src/Host.tsx
@@ -9,9 +9,7 @@ export default function Host() {
 
   const rawUrl = `${window.location.origin}${window.location.pathname}`;
 
-  const codeAndLink = rawUrl === 'https://voltrevo.github.io/2pc-is-for-lovers/'
-    ? `https://bit.ly/2pcifl#${key.base58()}`
-    : `${rawUrl}#${key.base58()}`;
+  const codeAndLink = `${rawUrl}#${key.base58()}`;
 
   useEffect(() => {
     ctx.host();


### PR DESCRIPTION
## What is this PR doing?

Bit.ly stopped forwarding hashes appended to their URLs, which is super not cool and means it's no longer useful for us. It's only minor anyway - it meant the resulting QR codes were a bit smaller so reading them was a bit more reliable.

## How can these changes be manually tested?

Run the app, check it still works.

## Does this PR resolve or contribute to any issues?

Nope.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
